### PR TITLE
Adjust letter formatting/CSS to match current standards

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -1,6 +1,7 @@
 @charset "utf-8";
 @namespace epub "http://www.idpf.org/2007/ops";
 
+/* letters */
 [epub|type~="z3998:letter"] header{
 	text-align: right;
 }
@@ -26,6 +27,12 @@ footer{
 	text-align: initial;
 	text-indent: 0;
 }
+/* end of letters */
+
+/* custom */
+[epub|type~="z3998:salutation"]{
+	text-align: initial;
+}
 
 #the-adventure-of-the-illustrious-client blockquote:nth-of-type(2){
 	font-variant: small-caps;
@@ -40,3 +47,4 @@ footer{
 #the-adventure-of-the-three-garridebs blockquote p:first-child{
 	font-variant: small-caps;
 }
+/* end of custom */

--- a/src/epub/text/the-adventure-of-the-three-gables.xhtml
+++ b/src/epub/text/the-adventure-of-the-three-gables.xhtml
@@ -37,9 +37,7 @@
 			<p>“But what is it?”</p>
 			<p>“I was going to tell you when we had this comic interlude. Here is <abbr>Mrs.</abbr> Maberley’s note. If you care to come with me we will wire her and go out at once.”</p>
 			<blockquote epub:type="z3998:letter">
-				<header>
-					<p epub:type="z3998:salutation">Dear <abbr>Mr.</abbr> Sherlock Holmes [I read]:</p>
-				</header>
+				<p><span epub:type="z3998:salutation">Dear <abbr>Mr.</abbr> Sherlock Holmes</span> [I read]:</p>
 				<p>I have had a succession of strange incidents occur to me in connection with this house, and I should much value your advice. You would find me at home any time tomorrow. The house is within a short walk of the Weald Station. I believe that my late husband, Mortimer Maberley, was one of your early clients.</p>
 				<footer>
 					<p epub:type="z3998:valediction">Yours faithfully,</p>

--- a/src/epub/text/the-problem-of-thor-bridge.xhtml
+++ b/src/epub/text/the-problem-of-thor-bridge.xhtml
@@ -28,7 +28,7 @@
 			<blockquote epub:type="z3998:letter">
 				<header>
 					<p epub:type="se:letter.dateline">Claridge’s Hotel, <time datetime="10-03">October 3rd</time></p>
-					<p epub:type="z3998:salutation">Dear <span epub:type="z3998:recipient"><abbr>Mr.</abbr> Sherlock Holmes</span>:</p>
+					<p epub:type="z3998:salutation">Dear <abbr>Mr.</abbr> Sherlock Holmes</span>:</p>
 				</header>
 				<p>I can’t see the best woman God ever made go to her death without doing all that is possible to save her. I can’t explain things⁠—I can’t even try to explain them, but I know beyond all doubt that Miss Dunbar is innocent. You know the facts⁠—who doesn’t? It has been the gossip of the country. And never a voice raised for her! It’s the damned injustice of it all that makes me crazy. That woman has a heart that wouldn’t let her kill a fly. Well, I’ll come at eleven tomorrow and see if you can get some ray of light in the dark. Maybe I have a clue and don’t know it. Anyhow, all I know and all I have and all I am are for your use if only you can save her. If ever in your life you showed your powers, put them now into this case.</p>
 				<footer>


### PR DESCRIPTION
A salutation that wasn't left(initial)-aligned, one in a header that didn't need to be, one that had extraneous text in the salutation tag, and an unnecessary recipient tag. From a report on the list.