### PR TITLE
Remove unneeded tag/selector

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -16,7 +16,6 @@ footer{
 }
 
 [epub|type~="z3998:sender"],
-[epub|type~="z3998:recipient"],
 [epub|type~="z3998:salutation"],
 [epub|type~="z3998:signature"]{
 	font-variant: small-caps;

--- a/src/epub/text/the-problem-of-thor-bridge.xhtml
+++ b/src/epub/text/the-problem-of-thor-bridge.xhtml
@@ -28,7 +28,7 @@
 			<blockquote epub:type="z3998:letter">
 				<header>
 					<p epub:type="se:letter.dateline">Claridge’s Hotel, <time datetime="10-03">October 3rd</time></p>
-					<p epub:type="z3998:salutation">Dear <abbr>Mr.</abbr> Sherlock Holmes</span>:</p>
+					<p epub:type="z3998:salutation">Dear <abbr>Mr.</abbr> Sherlock Holmes:</p>
 				</header>
 				<p>I can’t see the best woman God ever made go to her death without doing all that is possible to save her. I can’t explain things⁠—I can’t even try to explain them, but I know beyond all doubt that Miss Dunbar is innocent. You know the facts⁠—who doesn’t? It has been the gossip of the country. And never a voice raised for her! It’s the damned injustice of it all that makes me crazy. That woman has a heart that wouldn’t let her kill a fly. Well, I’ll come at eleven tomorrow and see if you can get some ray of light in the dark. Maybe I have a clue and don’t know it. Anyhow, all I know and all I have and all I am are for your use if only you can save her. If ever in your life you showed your powers, put them now into this case.</p>
 				<footer>


### PR DESCRIPTION
Hello!

Some quick cleanup after #4 earlier. A closing span tag was still around after losing its partner, and with the removal of that span tag, lint notes the selector is no longer required.