### PR TITLE
Fixed typo

### DIFF
--- a/src/epub/text/the-adventure-of-the-three-gables.xhtml
+++ b/src/epub/text/the-adventure-of-the-three-gables.xhtml
@@ -103,7 +103,7 @@
 			<p>“Nearly two.”</p>
 			<p>“All the better. During this long period no one wants anything from you. Now suddenly within three or four days you have urgent demands. What would you gather from that?”</p>
 			<p>“It can only mean,” said I, “that the object, whatever it may be, has only just come into the house.”</p>
-			<p>“Settled once again,” said Holmes. “Now, <abbr epub:type="z3998:name-title">Mrs.</abbr> Maberley has, any object just arrived?”</p>
+			<p>“Settled once again,” said Holmes. “Now, <abbr epub:type="z3998:name-title">Mrs.</abbr> Maberley, has any object just arrived?”</p>
 			<p>“No, I have bought nothing new this year.”</p>
 			<p>“Indeed! That is very remarkable. Well, I think we had best let matters develop a little further until we have clearer data. Is that lawyer of yours a capable man?”</p>
 			<p>“<abbr epub:type="z3998:name-title">Mr.</abbr> Sutro is most capable.”</p>


### PR DESCRIPTION
Source used: https://www.google.com/books/edition/The_Case_book_of_Sherlock_Holmes/lL9EAAAAYAAJ?hl=en&gbpv=1&bsq=%22Settled%20once%20again%22

Typo is located on Page 107 in the scan.